### PR TITLE
fix syntax in Print.py

### DIFF
--- a/Print.py
+++ b/Print.py
@@ -1,1 +1,1 @@
-print("Happy Hacktoberfest".)
+print("Happy Hacktoberfest.")


### PR DESCRIPTION
the `.` will cause a syntax error and should be within the quotes